### PR TITLE
Add details modal to dashboard page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ yarn-error.log*
 /src/MockAPI
 
 *.yaml
-env-config.js
+*env-config.js*

--- a/src/Components/Items/CardComponents/IngressCardComponent.tsx
+++ b/src/Components/Items/CardComponents/IngressCardComponent.tsx
@@ -1,7 +1,6 @@
 import {
   Typography,
   CircularProgress,
-  Link,
   TableRow,
   Stack,
   Table,

--- a/src/Components/Items/CardComponents/IngressCardComponent.tsx
+++ b/src/Components/Items/CardComponents/IngressCardComponent.tsx
@@ -1,8 +1,18 @@
-import { Typography, CircularProgress, Link } from "@mui/material";
+import {
+  Typography,
+  CircularProgress,
+  Link,
+  TableRow,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+} from "@mui/material";
 import CardComponent from "../CardComponent";
 import SettingsEthernetIcon from "@mui/icons-material/SettingsEthernet";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../App";
+import DetailsModal from "../DetailsModal";
 
 export default function IngressCardComponent() {
   const [ingress, setIngress] = useState([]);
@@ -54,15 +64,24 @@ export default function IngressCardComponent() {
             {ingressCount}
           </Typography>
           {ingressCount > 0 ? (
-            <div>
-              <Link
-                color="primary"
-                href="#"
-                onClick={() => alert("Add Service Account Modal!")}
-              >
-                Details
-              </Link>
-            </div>
+            <DetailsModal title="Ingresses">
+              <Stack>
+                <Table aria-label="simple table">
+                  <TableBody>
+                    {ingress.map((row) => (
+                      <TableRow
+                        key={row}
+                        sx={{
+                          "&:last-child td, &:last-child th": { border: 0 },
+                        }}
+                      >
+                        <TableCell align="center">{row}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Stack>
+            </DetailsModal>
           ) : (
             <></>
           )}

--- a/src/Components/Items/CardComponents/NamespaceCardComponent.tsx
+++ b/src/Components/Items/CardComponents/NamespaceCardComponent.tsx
@@ -1,8 +1,17 @@
-import { Typography, CircularProgress, Link } from "@mui/material";
+import {
+  Typography,
+  CircularProgress,
+  TableBody,
+  TableRow,
+  TableCell,
+  Stack,
+  Table,
+} from "@mui/material";
 import CardComponent from "../CardComponent";
 import { CubeTransparentIcon } from "@heroicons/react/outline";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../App";
+import DetailsModal from "../DetailsModal";
 
 export default function NamespaceCardComponent() {
   const [namespaceCount, setNameSpaceCount] = useState(0);
@@ -54,15 +63,24 @@ export default function NamespaceCardComponent() {
             {namespaceCount}
           </Typography>
           {namespaceCount > 0 ? (
-            <div>
-              <Link
-                color="primary"
-                href="#"
-                onClick={() => alert("Add Namespace Modal!")}
-              >
-                Details
-              </Link>
-            </div>
+            <DetailsModal title="Namespaces">
+              <Stack>
+                <Table aria-label="simple table">
+                  <TableBody>
+                    {namespaces.map((row) => (
+                      <TableRow
+                        key={row}
+                        sx={{
+                          "&:last-child td, &:last-child th": { border: 0 },
+                        }}
+                      >
+                        <TableCell align="center">{row}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Stack>
+            </DetailsModal>
           ) : (
             <></>
           )}

--- a/src/Components/Items/CardComponents/PodCardComponent.tsx
+++ b/src/Components/Items/CardComponents/PodCardComponent.tsx
@@ -1,7 +1,6 @@
 import {
   Typography,
   CircularProgress,
-  Link,
   Stack,
   Table,
   TableBody,

--- a/src/Components/Items/CardComponents/PodCardComponent.tsx
+++ b/src/Components/Items/CardComponents/PodCardComponent.tsx
@@ -1,8 +1,18 @@
-import { Typography, CircularProgress, Link } from "@mui/material";
+import {
+  Typography,
+  CircularProgress,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "@mui/material";
 import CardComponent from "../CardComponent";
 import ViewInAr from "@mui/icons-material/ViewInAr";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../App";
+import DetailsModal from "../DetailsModal";
 
 export default function PodCardComponent() {
   const [pods, setPods] = useState([]);
@@ -54,15 +64,24 @@ export default function PodCardComponent() {
             {podCount}
           </Typography>
           {podCount > 0 ? (
-            <div>
-              <Link
-                color="primary"
-                href="#"
-                onClick={() => alert("Add Service Account Modal!")}
-              >
-                Details
-              </Link>
-            </div>
+            <DetailsModal title="Pods">
+              <Stack>
+                <Table aria-label="simple table">
+                  <TableBody>
+                    {pods.map((row) => (
+                      <TableRow
+                        key={row}
+                        sx={{
+                          "&:last-child td, &:last-child th": { border: 0 },
+                        }}
+                      >
+                        <TableCell align="center">{row}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Stack>
+            </DetailsModal>
           ) : (
             <></>
           )}

--- a/src/Components/Items/CardComponents/ServiceAccountCardComponent.tsx
+++ b/src/Components/Items/CardComponents/ServiceAccountCardComponent.tsx
@@ -1,11 +1,21 @@
-import { Typography, CircularProgress, Link } from "@mui/material";
+import {
+  Typography,
+  CircularProgress,
+  Link,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow,
+} from "@mui/material";
 import CardComponent from "../CardComponent";
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../App";
+import DetailsModal from "../DetailsModal";
 
 export default function ServiceAccountCardComponent() {
-  const [serviceAccounts, setServiceAccounts] = useState();
+  const [serviceAccounts, setServiceAccounts] = useState([]);
   const [serviceAccountCount, setServiceAccountCount] = useState(0);
 
   const [serviceAccountsLoaded, setServiceAccountsLoaded] = useState(false);
@@ -29,13 +39,19 @@ export default function ServiceAccountCardComponent() {
         }
       ).then((res) => {
         res.json().then((jsonObj) => {
-          let counter = 0;
-          for (let sa in jsonObj) {
-            counter++;
+          if (jsonObj) {
+            let servAccs = [];
+            for (let sa in jsonObj) {
+              servAccs.push(sa);
+            }
+            setServiceAccountCount(servAccs.length);
+            setServiceAccounts(servAccs as []);
+            setServiceAccountsLoaded(true);
+          } else {
+            setServiceAccounts([]);
+            setServiceAccountCount(0);
+            setServiceAccountsLoaded(true);
           }
-          setServiceAccountCount(counter);
-          setServiceAccounts(jsonObj);
-          setServiceAccountsLoaded(true);
         });
       });
     }
@@ -53,15 +69,24 @@ export default function ServiceAccountCardComponent() {
             {serviceAccountCount}
           </Typography>
           {serviceAccountCount > 0 ? (
-            <div>
-              <Link
-                color="primary"
-                href="#"
-                onClick={() => alert("Add Service Account Modal!")}
-              >
-                Details
-              </Link>
-            </div>
+            <DetailsModal title="Service Accounts">
+              <Stack>
+                <Table aria-label="simple table">
+                  <TableBody>
+                    {serviceAccounts.map((row) => (
+                      <TableRow
+                        key={row}
+                        sx={{
+                          "&:last-child td, &:last-child th": { border: 0 },
+                        }}
+                      >
+                        <TableCell align="center">{row}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Stack>
+            </DetailsModal>
           ) : (
             <></>
           )}

--- a/src/Components/Items/CardComponents/ServiceAccountCardComponent.tsx
+++ b/src/Components/Items/CardComponents/ServiceAccountCardComponent.tsx
@@ -1,7 +1,6 @@
 import {
   Typography,
   CircularProgress,
-  Link,
   Stack,
   Table,
   TableBody,

--- a/src/Components/Items/DetailsModal.tsx
+++ b/src/Components/Items/DetailsModal.tsx
@@ -1,0 +1,64 @@
+import { Button, Divider, Modal, Stack, Typography } from "@mui/material";
+import { Box } from "@mui/system";
+import { useState } from "react";
+
+interface IDetailsModal {
+  title: string;
+  children?: any;
+}
+
+const style = {
+  position: "absolute" as "absolute",
+  top: "50%",
+  left: "50%",
+
+  transform: "translate(-50%, -50%)",
+  width: "auto",
+  bgcolor: "background.paper",
+  borderRadius: 2,
+  overflow: "scroll",
+  maxHeight: "75vh",
+  p: 4,
+  "::-webkit-scrollbar": {
+    width: "0px",
+    background: "transparent",
+  },
+};
+
+export default function DetailsModal(props: IDetailsModal) {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  return (
+    <div>
+      <Button onClick={handleOpen}>Details</Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box
+          sx={style}
+          style={{
+            overflowX: "hidden",
+            msOverflowStyle: "none",
+            scrollbarWidth: "none",
+          }}
+        >
+          <Stack spacing={2} alignItems="center">
+            <Stack spacing={1}>
+              <Typography component="p" variant="h4">
+                {props.title}
+              </Typography>
+              <Divider />
+            </Stack>
+
+            {props.children}
+          </Stack>
+        </Box>
+      </Modal>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a functioning details modal to the cards on the dashboard to display detailed information about certain ressources.

Signed-off-by: Michael Mumenthaler <michi.mumi@gmail.com>