### PR TITLE
add logout on 403

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,13 @@ function App() {
     }
   }, []);
 
+  useEffect(() => {
+    if (localStorage.getItem("tenant-api-token") !== authenticationToken) {
+      const newToken = localStorage.getItem("tenant-api-token");
+      setAuthenticationToken(newToken as string);
+    }
+  }, [localStorage.getItem("tenant-api-token")]);
+
   const Theme = createTheme({
     palette: {
       mode: "light",

--- a/src/Components/Cost.tsx
+++ b/src/Components/Cost.tsx
@@ -5,6 +5,7 @@ import CostTable from "./Items/CostTable";
 import { useState, useContext, useEffect } from "react";
 import { AuthenticationContext, TenantContext } from "../App";
 import FloatingTenantChange from "./Items/FloatingTenantChange";
+import { Logout } from "./Logout";
 
 export default function Cost() {
   const [totalCost, setTotalCost] = useState(0);
@@ -30,13 +31,17 @@ export default function Cost() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj) {
-            setCpuCost(jsonObj);
-          } else {
-            setCpuCost(0);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj) {
+              setCpuCost(jsonObj);
+            } else {
+              setCpuCost(0);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
 
       fetch(
@@ -48,13 +53,17 @@ export default function Cost() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj) {
-            setMemoryCost(jsonObj);
-          } else {
-            setMemoryCost(0);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj) {
+              setMemoryCost(jsonObj);
+            } else {
+              setMemoryCost(0);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
       fetch(
         `https://api.natron.io/api/v1/${tenantContext.selectedTenant}/costs/storage`,
@@ -79,6 +88,8 @@ export default function Cost() {
               setStorageObject(null);
             }
           });
+        } else if (res.status === 403) {
+          Logout();
         } else {
           setStorageCost(0);
           setStorageObject(null);
@@ -93,13 +104,17 @@ export default function Cost() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj) {
-            setIngressCost(jsonObj);
-          } else {
-            setIngressCost(0);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj) {
+              setIngressCost(jsonObj);
+            } else {
+              setIngressCost(0);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/IngressCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/IngressCardComponent.tsx
@@ -12,6 +12,7 @@ import SettingsEthernetIcon from "@mui/icons-material/SettingsEthernet";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
 import DetailsModal from "../../DetailsModal";
+import { Logout } from "../../../Logout";
 
 export default function IngressCardComponent() {
   const [ingress, setIngress] = useState([]);
@@ -36,17 +37,21 @@ export default function IngressCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj) {
-            setIngress(jsonObj);
-            setIngressCount(jsonObj.length);
-            setIngressLoaded(true);
-          } else {
-            setIngress([]);
-            setIngressCount(0);
-            setIngressLoaded(true);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj) {
+              setIngress(jsonObj);
+              setIngressCount(jsonObj.length);
+              setIngressLoaded(true);
+            } else {
+              setIngress([]);
+              setIngressCount(0);
+              setIngressLoaded(true);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/NamespaceCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/NamespaceCardComponent.tsx
@@ -12,6 +12,7 @@ import { CubeTransparentIcon } from "@heroicons/react/outline";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
 import DetailsModal from "../../DetailsModal";
+import { Logout } from "../../../Logout";
 
 export default function NamespaceCardComponent() {
   const [namespaceCount, setNameSpaceCount] = useState(0);
@@ -36,17 +37,21 @@ export default function NamespaceCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj === null) {
-            setNameSpaceCount(0);
-            setNameSpaces([]);
-            setNameSpacesLoaded(true);
-          } else {
-            setNameSpaceCount(jsonObj.length);
-            setNameSpaces(jsonObj);
-            setNameSpacesLoaded(true);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj === null) {
+              setNameSpaceCount(0);
+              setNameSpaces([]);
+              setNameSpacesLoaded(true);
+            } else {
+              setNameSpaceCount(jsonObj.length);
+              setNameSpaces(jsonObj);
+              setNameSpacesLoaded(true);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/PodCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/PodCardComponent.tsx
@@ -12,6 +12,7 @@ import ViewInAr from "@mui/icons-material/ViewInAr";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
 import DetailsModal from "../../DetailsModal";
+import { Logout } from "../../../Logout";
 
 export default function PodCardComponent() {
   const [pods, setPods] = useState([]);
@@ -36,17 +37,21 @@ export default function PodCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj) {
-            setPods(jsonObj);
-            setPodCount(jsonObj.length);
-            setPodsLoaded(true);
-          } else {
-            setPods([]);
-            setPodCount(0);
-            setPodsLoaded(true);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj) {
+              setPods(jsonObj);
+              setPodCount(jsonObj.length);
+              setPodsLoaded(true);
+            } else {
+              setPods([]);
+              setPodCount(0);
+              setPodsLoaded(true);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/RepositoryCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/RepositoryCardComponent.tsx
@@ -3,6 +3,7 @@ import CardComponent from "../../CardComponent";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
+import { Logout } from "../../../Logout";
 
 export default function RepositoryCardComponent() {
   const [repositoryLoaded, setRepositoryLoaded] = useState(false);
@@ -22,9 +23,13 @@ export default function RepositoryCardComponent() {
           Authorization: `Bearer ${authToken.authenticationToken}`,
         }),
       }).then((res) => {
+        if(res.status === 200){
         res.json().then((jsonObj) => {
           console.log("Repo loaded")
         });
+      } else if (res.status === 403) {
+          Logout();
+        }
       });*/
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/RessourceCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/RessourceCardComponent.tsx
@@ -5,6 +5,7 @@ import CpuIcon from "../../Icons/CpuIcon";
 import RamIcon from "../../Icons/RAMIcon";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
+import { Logout } from "../../../Logout";
 
 export default function RessourceCardComponent() {
   const [cpuCount, setCpuCount] = useState(0);
@@ -35,10 +36,14 @@ export default function RessourceCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          setCpuCount(jsonObj);
-          setCpuLoaded(true);
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            setCpuCount(jsonObj);
+            setCpuLoaded(true);
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
 
       fetch(
@@ -50,15 +55,19 @@ export default function RessourceCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          jsonObj = jsonObj / 1024 / 1024;
-          if (jsonObj >= 10000) {
-            jsonObj = jsonObj / 1024;
-            setRamMetric("GB");
-          }
-          setRamByteCount(jsonObj);
-          setRamLoaded(true);
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            jsonObj = jsonObj / 1024 / 1024;
+            if (jsonObj >= 10000) {
+              jsonObj = jsonObj / 1024;
+              setRamMetric("GB");
+            }
+            setRamByteCount(jsonObj);
+            setRamLoaded(true);
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/ServiceAccountCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/ServiceAccountCardComponent.tsx
@@ -12,6 +12,7 @@ import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
 import DetailsModal from "../../DetailsModal";
+import { Logout } from "../../../Logout";
 
 export default function ServiceAccountCardComponent() {
   const [serviceAccounts, setServiceAccounts] = useState([]);
@@ -37,21 +38,25 @@ export default function ServiceAccountCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj) {
-            let servAccs = [];
-            for (let sa in jsonObj) {
-              servAccs.push(sa);
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj) {
+              let servAccs = [];
+              for (let sa in jsonObj) {
+                servAccs.push(sa);
+              }
+              setServiceAccountCount(servAccs.length);
+              setServiceAccounts(servAccs as []);
+              setServiceAccountsLoaded(true);
+            } else {
+              setServiceAccounts([]);
+              setServiceAccountCount(0);
+              setServiceAccountsLoaded(true);
             }
-            setServiceAccountCount(servAccs.length);
-            setServiceAccounts(servAccs as []);
-            setServiceAccountsLoaded(true);
-          } else {
-            setServiceAccounts([]);
-            setServiceAccountCount(0);
-            setServiceAccountsLoaded(true);
-          }
-        });
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/CardComponents/Dashboard/StorageCardComponent.tsx
+++ b/src/Components/Items/CardComponents/Dashboard/StorageCardComponent.tsx
@@ -15,6 +15,7 @@ import StorageTwoToneIcon from "@mui/icons-material/StorageTwoTone";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext, TenantContext } from "../../../../App";
 import DonutChart from "../../DonutChart";
+import { Logout } from "../../../Logout";
 
 export default function StorageCardComponent() {
   const [selectedStorage, setSelectedStorage] = useState("");
@@ -61,17 +62,21 @@ export default function StorageCardComponent() {
           }),
         }
       ).then((res) => {
-        res.json().then((jsonObj) => {
-          if (jsonObj != null) {
-            SetStorageObject(jsonObj);
-            setStorage(Object.keys(jsonObj));
-            setStorageLoaded(true);
-          } else {
-            SetStorageObject("");
-            setStorage([]);
-            setStorageLoaded(true);
-          }
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            if (jsonObj != null) {
+              SetStorageObject(jsonObj);
+              setStorage(Object.keys(jsonObj));
+              setStorageLoaded(true);
+            } else {
+              SetStorageObject("");
+              setStorage([]);
+              setStorageLoaded(true);
+            }
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     }
   }, [tenantContext.selectedTenant]);

--- a/src/Components/Items/TenantDropdown.tsx
+++ b/src/Components/Items/TenantDropdown.tsx
@@ -8,6 +8,7 @@ import { Box } from "@mui/system";
 import { useContext, useEffect, useState } from "react";
 import { AuthenticationContext } from "../../App";
 import { TenantContext } from "../../App";
+import { Logout } from "../Logout";
 
 export default function TenantDropdown() {
   const [tenants, setTenants] = useState([]);
@@ -35,9 +36,13 @@ export default function TenantDropdown() {
           Authorization: `Bearer ${authToken.authenticationToken}`,
         }),
       }).then((res) => {
-        res.json().then((jsonObj) => {
-          tenantContext.updateTeanantList(jsonObj);
-        });
+        if (res.status === 200) {
+          res.json().then((jsonObj) => {
+            tenantContext.updateTeanantList(jsonObj);
+          });
+        } else if (res.status === 403) {
+          Logout();
+        }
       });
     } else {
       tenantContext.updateSelectedTenant(tenantContext.selectedTenant);

--- a/src/Components/Logout.tsx
+++ b/src/Components/Logout.tsx
@@ -2,6 +2,13 @@ import { Button } from "@mui/material";
 import { useContext } from "react";
 import { AuthenticationContext } from "../App";
 
+export function Logout() {
+  const authContext = useContext(AuthenticationContext);
+  localStorage.removeItem("tenant-api-token");
+  authContext.updateAuthenticationToken("");
+  authContext.updateAuthenticated(false);
+}
+
 export default function LogoutButton() {
   const authContext = useContext(AuthenticationContext);
 


### PR DESCRIPTION
This change is in conjunction of the token expiration functionality on the natron-api. 

- Add 403 handler to all fetch commands
- 403 will sign the user out of the frontend and remove the token from storage

Signed-off-by: Michael Mumenthaler <michi.mumi@gmail.com>